### PR TITLE
feat: changed the maximum values for EKF2_RNG_A_VMAX to 10 and EKF2_R…

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1128,7 +1128,7 @@ PARAM_DEFINE_INT32(EKF2_RNG_AID, 0);
  *
  * @group EKF2
  * @min 0.1
- * @max 2
+ * @max 10
  */
 PARAM_DEFINE_FLOAT(EKF2_RNG_A_VMAX, 1.0f);
 
@@ -1140,7 +1140,7 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_A_VMAX, 1.0f);
  *
  * @group EKF2
  * @min 1.0
- * @max 10.0
+ * @max 60.0
  */
 PARAM_DEFINE_FLOAT(EKF2_RNG_A_HMAX, 5.0f);
 


### PR DESCRIPTION
…NG_A_HMAX to 60

**Describe problem solved by this pull request**
Not being able to use the range fider as the primary source of altitude at an altitude past 10m and speed past 2 m/s

**Describe your solution**
Changing the maximum allowed values of EKF2_RNG_A_VMAX and EKF2_RNG_A_HMAX

**Describe possible alternatives**
None, straightforward change here.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

Fix was tested both indoors and outdoors, to ensure the modification was active and that the switchover at high altitudes / speed was performed successfully.

For a more detailed walk-through of the issue, please visit: https://app.asana.com/0/1151377094909881/1159021341251208/f

**Additional context**
This fix enables the use of lidar data for altitude in any indoor or low altitude outdoor environment. Then a switch to baro data if the craft flies above a certain height. 
